### PR TITLE
Add "Publish Playbooks" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,38 @@ When a service calls into another service it should offer a `Request-Id` and ide
 Services should instrument the time that it takes them to run and the time they spend calling into other services. If service time for the platform is degraded, it should be possible to tell whether time is being lost to a particular service or to degenerate network conditions.
 
 If an integration test is running against the platform and fails, it's not enough to know just that result; the test should be able to identify exactly which service caused its failure so that fixing it is immediately actionable.
+
+## Publish Playbooks
+
+Write playbooks for services that are simple enough operators who aren't core contributors to use successfully. Keep them succinct so that they're easy to reference and resistant to bit rot.
+
+---
+
+Services should ship with playbooks that describe the basic structure of deployments along with the most important operations that may need to be run during maintenance or an emergency. It's useful to imagine a playbook's reader as someone who isn't a core contributor to the project so that in a particularly rough spot, the service can still be operated even if none of its normal shepherds are present.
+
+Examples of what might be included in a playbook:
+
+* The service's deployment structure: which servers it resides on, what its critical dependencies are, instructions for carrying out a deployment, etc.
+* Links to important dashboards and other visibility tools.
+* The names of any alarms that might be triggered by the service, and what a human operator should do to resolve them.
+* A list of available control rods, a basic description of each, and how to activate them.
+
+## Succinctness
+
+Brevity is important for a few reasons:
+
+* A production incident is a very stressful time during which it can be difficult to think clearly or deeply. Documents that are amenable to being skimmed are particularly valuable during such a time. Commands in them should be "clipboard friendly" so that users can copy and run them easily and safely.
+* Documents that aren't in constant use tend to be susceptible to bit rot and quickly fall out of date. A succinct document is easier to update, and therefore less prone to this problem.
+
+### Executable Playbooks
+
+Playbooks are good, but executable playbooks are even better. Unfortunately, by definition playbooks are only referenced in unusual situations, and documentation that's not in constant use is incredibly prone to falling out-of-date.
+
+Mature services should consider shipping their own set of operator tools that empower even a naive operator to resolve all but the most unusual problems. Unlike documentation, programmatic tools can be compiled and tested in CI which is an incredibly powerful tool for ensuring their correctness.
+
+Some good practices:
+
+* Make operator tools trivial to install so that an operator responding to an incident can access them as soon as possible. A package repository that's already widely distributed internally is a good option.
+* Write good `--help` documentation that's useful even to a first time user. Include examples.
+* Write tests and run them in CI. There's nothing worse than a tool that fails as soon as it's needed.
+* Where possible, include tab completion and other niceties. The more discoverable and the _more quickly_ discoverable an interface is, the better.


### PR DESCRIPTION
Adds a section on writing some basic documentation for internal services.

cc @tt Would you mind taking a look at this one too? Thanks!